### PR TITLE
Revise the return code against judgement condition formula

### DIFF
--- a/prebuilt/common/bin/backuptool.sh
+++ b/prebuilt/common/bin/backuptool.sh
@@ -45,9 +45,10 @@ restore_addon_d() {
 check_prereq() {
 # If there is no build.prop file the partition is probably empty.
 if [ ! -r $S/build.prop ]; then
-    return 0
+  echo "Backup/restore is not possible. Partition is probably empty"
+  return 1
 fi
-return 1
+return 0
 }
 
 check_blacklist() {


### PR DESCRIPTION
Regarding the meaning of below judgement condition formula (a)
```C
if [ ! -r $S/build.prop ]; then  - - -(a)
```
Portion of 
```C
-r $S/build.prop
```
means "if build.prop exists".
Exclamation mark of "!" is to flip the result of that formula.
Then formula (a) means  "if build.prop does not exist" .

Therefore, original code of
```C
 if [ ! -r $S/build.prop ]; then
   return 0
 fi
   return 1
 }
```
should be revised as follow.
```C
 if [ ! -r $S/build.prop ]; then
   echo "Backup/restore is not possible. Partition is probably empty"
   return 1
 fi
   return 0
 }
```